### PR TITLE
Update Node.js version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: '18'
     - name: Install dependencies
       run: npm install
     - name: Run tests

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "vite": "^6.0.1",
     "vite-plugin-fable": "^0.0.32",
     "vitest": "^0.33.0"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
Update Node.js version in CI workflow to meet Vite's requirements.

* **package.json**
  - Add `engines` field specifying Node.js version 18 or higher.

* **.github/workflows/ci.yml**
  - Change `node-version` field to '18' in the `Set up Node.js` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jkone27/feliz-vite/pull/7?shareId=57c020c9-d2b0-47be-bdd9-e8fd5d9548ed).